### PR TITLE
Release USB interface of unmatched device

### DIFF
--- a/USB/mcc-libusb/pmd.c
+++ b/USB/mcc-libusb/pmd.c
@@ -138,6 +138,7 @@ libusb_device_handle* usb_device_find_USB_MCC( int productId, char *serialID )
         if (strcmp(serialID, serial) == 0) {
 	  break;
 	} else {
+	  libusb_release_interface(udev, 0);
 	  udev = NULL;
 	}
       } else {


### PR DESCRIPTION
We encountered a problem when starting up 2 separate processes using the find device function with serial ID. The first process claimed the interface even though it did not match the serial, then the second one could not use the already claimed devices.

By releasing the interface when the serial is not matched other processes can acquire access to the device.