### PR TITLE
include pmd.h in header

### DIFF
--- a/USB/mcc-libusb/usb-20X.h
+++ b/USB/mcc-libusb/usb-20X.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include "pmd.h"
 
 #define USB201_PID   (0x0113)
 #define USB202_PID   (0x012b)


### PR DESCRIPTION
Hi,
I'm a bit confused.
If I include the usb-20X.h headerfile I would assume that I don't have to include other dependencies.
So just include this header file?