### PR TITLE
corrected an error in writing to user memory space for 1608FS Plus li…

### DIFF
--- a/USB/mcc-libusb/usb-1608FS-Plus.c
+++ b/USB/mcc-libusb/usb-1608FS-Plus.c
@@ -308,10 +308,10 @@ int usbAInScanRead_USB1608FS_Plus(libusb_device_handle *udev, int nScan, int nCh
     for (i = 0; i < nbytes/2; i++) {
       ret = libusb_bulk_transfer(udev, LIBUSB_ENDPOINT_IN|1, (unsigned char *) &data[i], 2, &transferred, 2000);
       if (ret < 0) {
-	perror("usbAInScanRead_USB1608FS_Plus: error in usb_bulk_transfer.");
+				perror("usbAInScanRead_USB1608FS_Plus: error in usb_bulk_transfer.");
       }
       if (transferred != 2) {
-	fprintf(stderr, "usbAInScanRead_USB1608_Plus: number of bytes transferred = %d, nbytes = %d\n", transferred, nbytes);
+				fprintf(stderr, "usbAInScanRead_USB1608_Plus: number of bytes transferred = %d, nbytes = %d\n", transferred, nbytes);
       }
     }
   } else { 
@@ -323,9 +323,9 @@ int usbAInScanRead_USB1608FS_Plus(libusb_device_handle *udev, int nScan, int nCh
       fprintf(stderr, "usbAInScanRead_USB1608_Plus: number of bytes transferred = %d, nbytes = %d\n", transferred, nbytes);
       status = usbStatus_USB1608FS_Plus(udev);
       if ((status & AIN_SCAN_OVERRUN)) {
-	fprintf(stderr, "Analog AIn scan overrun.\n");
-	usbAInScanStop_USB1608FS_Plus(udev);
-	usbAInScanClearFIFO_USB1608FS_Plus(udev);
+				fprintf(stderr, "Analog AIn scan overrun.\n");
+				usbAInScanStop_USB1608FS_Plus(udev);
+				usbAInScanClearFIFO_USB1608FS_Plus(udev);
       }
       return ret;
     }
@@ -497,13 +497,13 @@ void usbWriteUserMemory_USB1608FS_Plus(libusb_device_handle *udev, uint16_t addr
 
   uint8_t requesttype = (HOST_TO_DEVICE | VENDOR_TYPE | DEVICE_RECIPIENT);
 
-  if (count > 255) {
-    printf("usbWriteUserMemory_USB1608FS_Plus: max bytes that can be written is 768.");
+  if (count > 256) {
+    printf("usbWriteUserMemory_USB1608FS_Plus: max bytes that can be written is 256.");
     return;
   }
 
   if (address > 0xff) {
-    printf("usbWriteUserMemory_USB1608FS_Plus: address must be in the range 0 - 0x2ff.");
+    printf("usbWriteUserMemory_USB1608FS_Plus: address must be in the range 0 - 0xff.");
     return;
   }
   libusb_control_transfer(udev, requesttype, USER_MEMORY, address, 0x0, (unsigned char *) data, count, HS_DELAY);


### PR DESCRIPTION
Corrected a logic error in function `usbWriteUserMemory_USB1608FS_Plus` in the 1608FS-Plus library.

The documentation reads that user space is only 256 bytes of addressable memory, those addresses include `0x00-0xFF`. The guard is off by one `255`, and the error message was incorrect.

