### PR TITLE
Update Linux_Drivers USB functions to compile on Clang.

### DIFF
--- a/USB/mcc-libusb/Makefile
+++ b/USB/mcc-libusb/Makefile
@@ -30,7 +30,10 @@ HEADERS = pmd.h usb-500.h usb-1608G.h usb-20X.h usb-1208FS-Plus.h usb-1608FS-Plu
           bth-1208LS.h minilab-1008.h usb-1808.h
 OBJS = $(SRCS:.c=.o)   # same list as SRCS with extension changed
 CC=gcc
-CFLAGS+= -g -Wall -fPIC -O -I/usr/local/include/libusb-1.0 -L/usr/local/lib -lusb-1.0
+INCLUDES += -I. -I/opt/local/include
+#CFLAGS+= -g -Wall -fPIC -O -I/opt/local/include/libusb-1.0 -L/opt/local/lib -L/opt/local/lib -lusb-1.0
+CFLAGS+= -g -Wall -fPIC -O $(INCLUDES)
+LDFLAGS += -L/opt/local/lib -lusb-1.0 -lhidapi
 ifeq ($(shell uname), Darwin)
 	SONAME_FLAGS = -install_name
 	SHARED_EXT = dylib
@@ -52,7 +55,7 @@ DIST_FILES={README,Makefile,nist.c,pmd.c,pmd.h,usb-1608G.h,usb-1608G.rbf,usb-160
 all: $(TARGETS)
 
 %.d: %.c
-	set -e; $(CC) -I. -M $(CPPFLAGS) $< \
+	set -e; $(CC) $(INCLUDES) -M $(CPPFLAGS) $< \
 	| sed 's/\($*\)\.o[ :]*/\1.o $@ : /g' > $@; \
 	[ -s $@ ] || rm -f $@
 ifneq ($(MAKECMDGOALS),clean)
@@ -61,7 +64,7 @@ endif
 
 libmccusb.$(SHARED_EXT): $(OBJS)
 #	$(CC) -O -shared -Wall $(OBJS) -o $@
-	$(CC) -shared -Wl,$(SONAME_FLAGS),$@ -o $@ $(OBJS) -lc -lm $(CFLAGS)
+	$(CC) -shared -Wl,$(SONAME_FLAGS),$@ -o $@ $(OBJS) -lc -lm $(CFLAGS) $(LDFLAGS)
 
 libmccusb.a: $(OBJS)
 	ar -r libmccusb.a $(OBJS)
@@ -71,123 +74,123 @@ libmccusb.a: $(OBJS)
 # libusb-1.0
 #
 test-usb500:  test-usb500.c
-	$(CC) -g -Wall -I. -o $@ $@.c -lm -lusb-1.0
+	$(CC) -g -Wall  $(INCLUDES) -o $@ $@.c -lm $(LDFLAGS)
 
 test-usb1608G:	test-usb1608G.c usb-1608G.o libmccusb.a
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb1808:	test-usb1808.c usb-1808.o libmccusb.a
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb2020:	test-usb2020.c usb-2020.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb1208FS-Plus:	test-usb1208FS-Plus.c usb-1208FS-Plus.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb1608FS-Plus:	test-usb1608FS-Plus.c usb-1608FS-Plus.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS)
 
 test-usb1208HS:	test-usb1208HS.c usb-1208HS.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb1608HS:	test-usb1608HS.c usb-1608HS.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb20X:	test-usb20X.c usb-20X.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb2600:	test-usb2600.c usb-2600.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb2408:	test-usb2408.c usb-2408.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb2416:	test-usb2416.c usb-2416.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb-ctr:	test-usb-ctr.c usb-ctr.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb2001tc: test-usb2001tc.c usb-2001-tc.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb7202: test-usb7202.c usb-7202.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb7204: test-usb7204.c usb-7204.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS)
 
 test-usb-dio32HS: test-usb-dio32HS.c usb-dio32HS.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS)
 
 test-usb-tc32: test-usb-tc32.c usb-tc-32.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS)
 
 test-bth1208LS: test-bth1208LS.c bth-1208LS.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS)
 
 
 ################ HID devices ##########################
 test-minilab1008: test-minilab1008.c minilab-1008.o libmccusb.a
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS)
 
 test-usb1024LS:	test-usb1024LS.c usb-1024LS.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb-dio24:	test-usb-dio24.c usb-dio24.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb-dio96H: test-usb-dio96H.c usb-dio96H.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb1208LS:	test-usb1208LS.c usb-1208LS.o libmccusb.a
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb1208FS:	test-usb1208FS.c usb-1208FS.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb1408FS:	test-usb1408FS.c usb-1408FS.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb1608FS:	test-usb1608FS.c usb-1608FS.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb1616FS:	test-usb1616FS.c usb-1616FS.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS)
 
 test-usb3100:	test-usb3100.c usb-3100.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS)
 
 test-usb4300:	test-usb4300.c usb-4303.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS)
 
 test-usb5201: test-usb5201.c usb-5200.o libmccusb.a
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb5203: test-usb5203.c usb-5200.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib  -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb-tc: test-usb-tc.c usb-tc.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib  -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb-tc-ai: test-usb-tc-ai.c usb-tc-ai.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib  -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb-temp: test-usb-temp.c usb-temp.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib  -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb-temp-ai: test-usb-temp-ai.c usb-tc-ai.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib  -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb-ssr: test-usb-ssr.c usb-ssr.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib  -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb-erb: test-usb-erb.c usb-erb.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib  -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 test-usb-pdiso8: test-usb-pdiso8.c usb-pdiso8.o libmccusb.a 
-	$(CC) -g -Wall -I. -o $@ $@.c -L. -lmccusb  -lm -L/usr/local/lib  -lhidapi-libusb -lusb-1.0 
+	$(CC) -g -Wall $(INCLUDES) -o $@ $@.c -L. -lmccusb  -lm $(LDFLAGS) 
 
 ####################################################################################################
 
@@ -199,14 +202,14 @@ dist:
 	cd ..; tar -zcvf $(DIST_NAME) mcc-libusb/$(DIST_FILES);
 
 install:
-	-install -d /usr/local/lib
-	-install -c --mode=0755 ./libmccusb.a libmccusb.$(SHARED_EXT) /usr/local/lib
-	-/bin/ln -s /usr/local/lib/libmccusb.$(SHARED_EXT) /usr/lib/libmccusb.$(SHARED_EXT)
-	-/bin/ln -s /usr/local/lib/libmccusb.a /usr/lib/libmccusb.a
-	-install -d /usr/local/include/libusb
-	-install -c --mode=0644 ${HEADERS} /usr/local/include/libusb/
+	-install -d /opt/local/lib
+	-install -c --mode=0755 ./libmccusb.a libmccusb.$(SHARED_EXT) /opt/local/lib
+	-/bin/ln -s /opt/local/lib/libmccusb.$(SHARED_EXT) /usr/lib/libmccusb.$(SHARED_EXT)
+	-/bin/ln -s /opt/local/lib/libmccusb.a /usr/lib/libmccusb.a
+	-install -d /opt/local/include/libusb
+	-install -c --mode=0644 ${HEADERS} /opt/local/include/libusb/
 
 uninstall:
-	-rm -f /usr/local/lib/libmccusb*
+	-rm -f /opt/local/lib/libmccusb*
 	-rm -f /usr/lib/libmccusb*
-	-rm -rf /usr/local/include/libusb
+	-rm -rf /opt/local/include/libusb

--- a/USB/mcc-libusb/test-usb-tc32.c
+++ b/USB/mcc-libusb/test-usb-tc32.c
@@ -235,7 +235,7 @@ int main (int argc, char **argv)
 	printf("Communcations mico bootloader firmware version = %x.%x\n", version.boot_version_comms>>8, version.boot_version_comms&0xff);
 	printf("Base measurement micro firmware version = %x.%x\n", version.version_base>>8,version.version_base&0xff);
 	printf("Base measurement micro bootloader firmware version = %x.%x\n", version.boot_version_base>>8,version.boot_version_base&0xff);
-	printf("EXP measurement micro firmware version = %x.%x\n", version.version_exp>>8,version.version_exp&&0xff);
+	printf("EXP measurement micro firmware version = %x.%x\n", version.version_exp>>8,version.version_exp&0xff);
 	printf("EXP measurement micro bootloader firmware version = %x.%x\n\n", version.boot_version_exp>>8,version.boot_version_exp&0xff);
 	usbCalDate_TC32(udev, &date_base, &date_exp);
 	printf("Calibration date = %s\n", asctime(&date_base));

--- a/USB/mcc-libusb/test-usb1608FS.c
+++ b/USB/mcc-libusb/test-usb1608FS.c
@@ -47,7 +47,7 @@ int main (int argc, char **argv)
   int temp, i,j;
   int ch;
   uint8_t gainArray[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-  int16_t sdata[1024*8];
+  uint16_t sdata[1024*8];
   uint16_t data[2048*8];
   int count;
   int options;

--- a/USB/mcc-libusb/test-usb2020.c
+++ b/USB/mcc-libusb/test-usb2020.c
@@ -25,7 +25,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <sys/types.h>
-#include <asm/types.h>
+//#include <asm/types.h>
 
 #include "pmd.h"
 #include "usb-2020.h"
@@ -126,7 +126,7 @@ int main (int argc, char **argv)
 	do {
           printf("Enter a  number [0-0xf]: " );
           scanf("%x", &temp);
-          temp = temp;
+//          temp = temp;
           usbDLatchW_USB2020(device.udev, (uint16_t)temp);
 	  temp = usbDLatchR_USB2020(device.udev);
           input = (usbDPort_USB2020(device.udev) >> 4) & 0xf;

--- a/USB/mcc-libusb/test-usb5201.c
+++ b/USB/mcc-libusb/test-usb5201.c
@@ -66,7 +66,7 @@ void readHeader(int fd, file_header *header)
   printf("Header information: \n");
   printf("MCC file identifier = %#x\tData file version = %d\tLogging options = %#x\n",
 	 header->identifier, header->version, header->options);
-  printf("Channels logged = %#x\t\tData units = %d\t\tNumber of seconds between entries = %hd\n",
+  printf("Channels logged = %#x\t\tData units = %d\t\tNumber of seconds between entries = %d\n",
 	 header->channels, header->units, second);
   memcpy(&date, header->start_time, 6);  // note time_zone not logged into header.
   second = (date.seconds >> 4)*10 + (date.seconds & 0xf);

--- a/USB/mcc-libusb/test-usb5203.c
+++ b/USB/mcc-libusb/test-usb5203.c
@@ -66,7 +66,7 @@ void readHeader(int fd, file_header *header)
   printf("Header information: \n");
   printf("MCC file identifier = %#x\tData file version = %d\tLogging options = %#x\n",
 	 header->identifier, header->version, header->options);
-  printf("Channels logged = %#x\t\tData units = %d\t\tNumber of seconds between entries = %hd\n",
+  printf("Channels logged = %#x\t\tData units = %d\t\tNumber of seconds between entries = %d\n",
 	 header->channels, header->units, second);
   memcpy(&date, header->start_time, 6);  // note time_zone not logged into header.
   second = (date.seconds >> 4)*10 + (date.seconds & 0xf);

--- a/USB/mcc-libusb/usb-1408FS.c
+++ b/USB/mcc-libusb/usb-1408FS.c
@@ -876,12 +876,12 @@ int usbWriteMemory_USB1408FS(libusb_device_handle *udev, uint16_t address, uint8
 {
   // Locations 0x00-0x7F are reserved for firmware and my not be written.
   int i;
-  struct arg {
+  struct mem_write_report_t {
     uint8_t  reportID;
     uint8_t  address[2];
     uint8_t  count;
-    uint8_t  data[count];
-  } arg;
+    uint8_t  data[1];
+  } *arg = NULL;
 
   int ret;
   uint8_t request_type = LIBUSB_REQUEST_TYPE_CLASS|LIBUSB_RECIPIENT_INTERFACE|LIBUSB_ENDPOINT_OUT;
@@ -892,17 +892,23 @@ int usbWriteMemory_USB1408FS(libusb_device_handle *udev, uint16_t address, uint8
   if (address <=0x7f) return -1;
   if (count > 59) count = 59;
 
-  arg.reportID = MEM_WRITE;
-  arg.address[0] = address & 0xff;
-  arg.address[1] = (address >> 8) & 0xff;
-  arg.count = count;
-  for ( i = 0; i < count; i++ ) {
-    arg.data[i] = data[i];
+  arg = (struct mem_write_report_t *) malloc(sizeof(struct mem_write_report_t) + count * sizeof(uint8_t) );
+  if(!arg) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
   }
-  ret = libusb_control_transfer(udev, request_type, request, wValue, wIndex, (unsigned char*) &arg, sizeof(arg), 5000);
+  arg->reportID = MEM_WRITE;
+  arg->address[0] = address & 0xff;
+  arg->address[1] = (address >> 8) & 0xff;
+  arg->count = count;
+  for ( i = 0; i < count; i++ ) {
+    arg->data[i] = data[i];
+  }
+  ret = libusb_control_transfer(udev, request_type, request, wValue, wIndex, (unsigned char*) arg, sizeof(struct mem_write_report_t)+count-1, 5000);
   if (ret < 0) {
     perror("Error in usbWriteMemory_USB1408FS: libusb_control_transfer error");
   }
+  free(arg);
   return 0;
 }
 

--- a/USB/mcc-libusb/usb-1608FS.c
+++ b/USB/mcc-libusb/usb-1608FS.c
@@ -495,7 +495,7 @@ int16_t usbAIn_USB1608FS(libusb_device_handle *udev, uint8_t channel, uint8_t ra
 {
   int transferred;
   uint16_t data;
-  int16_t value = 0;
+  uint16_t value = 0;
   uint8_t report[3];
 
   struct ain_t {
@@ -1061,8 +1061,8 @@ int usbWriteMemory_USB1608FS(libusb_device_handle *udev, uint16_t address, uint8
     uint8_t reportID;
     uint8_t address[2];
     uint8_t count;
-    uint8_t data[count];
-  } arg;
+    uint8_t data[1];
+  } *arg = NULL;
 
   int ret;
   uint8_t request_type = LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT;
@@ -1073,19 +1073,25 @@ int usbWriteMemory_USB1608FS(libusb_device_handle *udev, uint16_t address, uint8
   if (address <= 0x7f) return -1;         //
   if (count > 59) count = 59;             // a max of 59 bytes can be written to EEPROM memory
 
-  arg.reportID = MEM_WRITE;
-  arg.address[0] = address & 0xff;        // low byte
-  arg.address[1] = (address >> 8) & 0xff; // high byte
-  arg.count = count;
+  arg = (struct mem_write_report_t *) malloc(sizeof(struct mem_write_report_t) + count * sizeof(uint8_t) );
+  if(!arg) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
+  }
+  arg->reportID = MEM_WRITE;
+  arg->address[0] = address & 0xff;        // low byte
+  arg->address[1] = (address >> 8) & 0xff; // high byte
+  arg->count = count;
 
   for (i = 0; i < count; i++) {
-    arg.data[i] = data[i];
+    arg->data[i] = data[i];
   }
 
-  ret = libusb_control_transfer(udev, request_type, request, wValue, wIndex, (unsigned char*) &arg, sizeof(arg), 5000);
+  ret = libusb_control_transfer(udev, request_type, request, wValue, wIndex, (unsigned char*) arg, sizeof(struct mem_write_report_t)+count-1, 5000);
   if (ret < 0) {
     perror("Error in usbWriteMemory_USB1608FS: libusb_control_transfer error");
   }
+  free(arg);
   return 0;
 }
 

--- a/USB/mcc-libusb/usb-1616FS.c
+++ b/USB/mcc-libusb/usb-1616FS.c
@@ -343,7 +343,7 @@ int16_t usbAIn_USB1616FS(libusb_device_handle *udev, uint8_t channel, uint8_t ra
   int transferred;
 
   uint16_t data;
-  int16_t value = 0;
+  uint16_t value = 0;
   uint8_t report[3];
 
   struct ain_t {
@@ -513,7 +513,7 @@ int usbAInScan_USB1616FS(libusb_device_handle *udev, uint8_t lowchannel, uint8_t
   int transferred;
   int timeout = FS_DELAY;
 
-  int16_t value;
+  uint16_t value;
   uint16_t uvalue;
   uint8_t gain;    
 
@@ -924,8 +924,8 @@ int usbWriteMemory_USB1616FS(libusb_device_handle *udev, uint16_t address, uint8
     uint8_t reportID;
     uint8_t address[2];
     uint8_t count;
-    uint8_t data[count];
-  } arg;
+    uint8_t data[1];
+  } *arg = NULL;
 
   int ret;
   uint8_t request_type = LIBUSB_REQUEST_TYPE_CLASS|LIBUSB_RECIPIENT_INTERFACE|LIBUSB_ENDPOINT_OUT;
@@ -936,19 +936,25 @@ int usbWriteMemory_USB1616FS(libusb_device_handle *udev, uint16_t address, uint8
   if ( address <=0x7f ) return -1;
   if ( count > 59 ) count = 59;
 
-  arg.reportID = MEM_WRITE;
-  arg.address[0] = address & 0xff;         // low byte
-  arg.address[1] = (address >> 8) & 0xff;  // high byte
+  arg = (struct mem_write_report_t *) malloc(sizeof(struct mem_write_report_t) + count * sizeof(uint8_t) );
+  if(!arg) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
+  }
+  arg->reportID = MEM_WRITE;
+  arg->address[0] = address & 0xff;         // low byte
+  arg->address[1] = (address >> 8) & 0xff;  // high byte
 
-  arg.count = count;
+  arg->count = count;
   for ( i = 0; i < count; i++ ) {
-    arg.data[i] = data[i];
+    arg->data[i] = data[i];
   }
 
-  ret = libusb_control_transfer(udev, request_type, request, wValue, wIndex, (unsigned char*) &arg, sizeof(arg), 5000);
+  ret = libusb_control_transfer(udev, request_type, request, wValue, wIndex, (unsigned char*) arg, sizeof(struct mem_write_report_t)+count-1, 5000);
   if (ret < 0) {
     perror("Error in usbWriteMemory_USB1616FS: libusb_control_transfer error");
   }
+  free(arg);
   return 0;
 }
 

--- a/USB/mcc-libusb/usb-5200.c
+++ b/USB/mcc-libusb/usb-5200.c
@@ -292,21 +292,27 @@ int usbWriteMemory_USB5200(hid_device *hid, uint16_t address, uint8_t type, uint
     uint16_t address;   // start address for the write (0x00-0xFF)
     uint8_t  type;      // 0 = main microcontroller  1 = isolated microcontroller
     uint8_t  count;     // number of bytes to write (59 max)
-    uint8_t  data[count];
-  } writeMemory;
+    uint8_t  data[1];
+  } *writeMemory = NULL;
 
   if (address > 0xff) return -1;
   if (count > 59) count = 59;
 
-  writeMemory.reportID = MEM_WRITE;
-  writeMemory.address = address;
-  writeMemory.count = count;
-  writeMemory.type = type;
+  writeMemory = (struct writeMemory_t *) malloc(sizeof(struct writeMemory_t) + count * sizeof(uint8_t) );
+  if(!writeMemory) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
+  }
+  writeMemory->reportID = MEM_WRITE;
+  writeMemory->address = address;
+  writeMemory->count = count;
+  writeMemory->type = type;
 
   for ( i = 0; i < count; i++ ) {
-    writeMemory.data[i] = data[i];
+    writeMemory->data[i] = data[i];
   }
-  PMD_SendOutputReport(hid, (uint8_t *) &writeMemory, sizeof(writeMemory));
+  PMD_SendOutputReport(hid, (uint8_t *) writeMemory, sizeof(struct writeMemory_t)+count-1);
+  free(writeMemory);
   return 0;
 }
 

--- a/USB/mcc-libusb/usb-dio96H.c
+++ b/USB/mcc-libusb/usb-dio96H.c
@@ -200,21 +200,27 @@ int usbWriteMemory_USBDIO96H(hid_device *hid, uint16_t address, uint8_t count, u
     uint8_t reportID;
     uint8_t address[2];
     uint8_t count;
-    uint8_t data[count];
-  } arg;
+    uint8_t data[1];
+  } *arg = NULL;
 
   if ( address <=0x7f ) return -1;
   if ( count > 59 ) count = 59;
 
-  arg.reportID = MEM_WRITE;
-  arg.address[0] = address & 0xff;         // low byte
-  arg.address[1] = (address >> 8) & 0xff;  // high byte
-
-  arg.count = count;
-  for ( i = 0; i < count; i++ ) {
-    arg.data[i] = data[i];
+  arg = (struct mem_write_report_t *) malloc(sizeof(struct mem_write_report_t) + count * sizeof(uint8_t) );
+  if(!arg) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
   }
-  PMD_SendOutputReport(hid, (uint8_t *) &arg, sizeof(arg));
+  arg->reportID = MEM_WRITE;
+  arg->address[0] = address & 0xff;         // low byte
+  arg->address[1] = (address >> 8) & 0xff;  // high byte
+
+  arg->count = count;
+  for ( i = 0; i < count; i++ ) {
+    arg->data[i] = data[i];
+  }
+  PMD_SendOutputReport(hid, (uint8_t *) arg, sizeof(struct mem_write_report_t)+count-1);
+  free(arg);
   return 0;
 }
 

--- a/USB/mcc-libusb/usb-erb.c
+++ b/USB/mcc-libusb/usb-erb.c
@@ -158,21 +158,27 @@ int usbWriteMemory_USBERB(hid_device *hid, uint16_t address, uint8_t count, uint
     uint8_t reportID;
     uint8_t address[2];
     uint8_t count;
-    uint8_t data[count];
-  } arg;
+    uint8_t data[1];
+  } *arg = NULL;
 
   if ( address <= 0x7f ) return -1;
   if ( count > 59 ) count = 59;
 
-  arg.reportID = MEM_WRITE;
-  arg.address[0] = address & 0xff;         // low byte
-  arg.address[1] = (address >> 8) & 0xff;  // high byte
-
-  arg.count = count;
-  for ( i = 0; i < count; i++ ) {
-    arg.data[i] = data[i];
+  arg = (struct mem_write_report_t *) malloc(sizeof(struct mem_write_report_t) + count * sizeof(uint8_t) );
+  if(!arg) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
   }
-  PMD_SendOutputReport(hid, (uint8_t *) &arg, sizeof(arg));
+  arg->reportID = MEM_WRITE;
+  arg->address[0] = address & 0xff;         // low byte
+  arg->address[1] = (address >> 8) & 0xff;  // high byte
+
+  arg->count = count;
+  for ( i = 0; i < count; i++ ) {
+    arg->data[i] = data[i];
+  }
+  PMD_SendOutputReport(hid, (uint8_t *) arg, sizeof(struct mem_write_report_t)+count-1);
+  free(arg);
   return 0;
 }
 

--- a/USB/mcc-libusb/usb-pdiso8.c
+++ b/USB/mcc-libusb/usb-pdiso8.c
@@ -144,21 +144,27 @@ int usbWriteMemory_USBPDISO8(hid_device *hid, uint16_t address, uint8_t count, u
     uint8_t reportID;
     uint8_t address[2];
     uint8_t count;
-    uint8_t data[count];
-  } arg;
+    uint8_t data[1];
+  } *arg = NULL;
 
   if (address <= 0xf) return -1;
   if (count > 4) count = 4;
 
-  arg.reportID = MEM_WRITE;
-  arg.address[0] = address & 0xff;         // low byte
-  arg.address[1] = (address >> 8) & 0xff;  // high byte
-
-  arg.count = count;
-  for ( i = 0; i < count; i++ ) {
-    arg.data[i] = data[i];
+  arg = (struct mem_write_report_t *) malloc(sizeof(struct mem_write_report_t) + count * sizeof(uint8_t) );
+  if(!arg) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
   }
-  PMD_SendOutputReport(hid, (uint8_t *) &arg, sizeof(arg));
+  arg->reportID = MEM_WRITE;
+  arg->address[0] = address & 0xff;         // low byte
+  arg->address[1] = (address >> 8) & 0xff;  // high byte
+
+  arg->count = count;
+  for ( i = 0; i < count; i++ ) {
+    arg->data[i] = data[i];
+  }
+  PMD_SendOutputReport(hid, (uint8_t *) arg, sizeof(struct mem_write_report_t)+count-1);
+  free(arg);
   return 0;
 }
 

--- a/USB/mcc-libusb/usb-ssr.c
+++ b/USB/mcc-libusb/usb-ssr.c
@@ -146,21 +146,27 @@ int usbWriteMemory_USBSSR(hid_device *hid, uint16_t address, uint8_t count, uint
     uint8_t reportID;
     uint8_t address[2];
     uint8_t count;
-    uint8_t data[count];
-  } arg;
+    uint8_t data[1];
+  } *arg = NULL;
 
   if (address <= 0x7f) return -1;
   if (count > 59) count = 59;
 
-  arg.reportID = MEM_WRITE;
-  arg.address[0] = address & 0xff;         // low byte
-  arg.address[1] = (address >> 8) & 0xff;  // high byte
-
-  arg.count = count;
-  for (i = 0; i < count; i++) {
-    arg.data[i] = data[i];
+  arg = (struct mem_write_report_t *) malloc(sizeof(struct mem_write_report_t) + count * sizeof(uint8_t) );
+  if(!arg) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
   }
-  PMD_SendOutputReport(hid, (uint8_t *) &arg, sizeof(arg));
+  arg->reportID = MEM_WRITE;
+  arg->address[0] = address & 0xff;         // low byte
+  arg->address[1] = (address >> 8) & 0xff;  // high byte
+
+  arg->count = count;
+  for (i = 0; i < count; i++) {
+    arg->data[i] = data[i];
+  }
+  PMD_SendOutputReport(hid, (uint8_t *) arg, sizeof(struct mem_write_report_t)+count-1);
+  free(arg);
   return 0;
 }
 

--- a/USB/mcc-libusb/usb-tc-ai.c
+++ b/USB/mcc-libusb/usb-tc-ai.c
@@ -320,21 +320,27 @@ int usbWriteMemory_USBTC_AI(hid_device *hid, uint16_t address, uint8_t type, uin
     uint16_t address;   // start address for the write (0x00-0xFF)
     uint8_t  type;      // 0 = main microcontroller  1 = isolated microcontroller
     uint8_t  count;     // number of bytes to write (59 max)
-    uint8_t  data[count];
-  } writeMemory;
+    uint8_t  data[1];
+  } *writeMemory = NULL;
 
   if (address > 0xff) return -1;
   if (count > 59) count = 59;
 
-  writeMemory.reportID = MEM_WRITE;
-  writeMemory.address = address;
-  writeMemory.count = count;
-  writeMemory.type = type;
+  writeMemory = (struct writeMemory_t *) malloc(sizeof(struct writeMemory_t) + count * sizeof(uint8_t) );
+  if(!writeMemory) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
+  }
+  writeMemory->reportID = MEM_WRITE;
+  writeMemory->address = address;
+  writeMemory->count = count;
+  writeMemory->type = type;
 
   for ( i = 0; i < count; i++ ) {
-    writeMemory.data[i] = data[i];
+    writeMemory->data[i] = data[i];
   }
-  PMD_SendOutputReport(hid, (uint8_t *) &writeMemory, sizeof(writeMemory));
+  PMD_SendOutputReport(hid, (uint8_t *) writeMemory, sizeof(struct writeMemory_t)+count-1);
+  free(writeMemory);
   return 0;
 }
 

--- a/USB/mcc-libusb/usb-tc.c
+++ b/USB/mcc-libusb/usb-tc.c
@@ -276,23 +276,28 @@ int usbWriteMemory_USBTC(hid_device *hid, uint16_t address, uint8_t type, uint8_
     uint16_t address;   // start address for the write (0x00-0xFF)
     uint8_t  type;      // 0 = main microcontroller  1 = isolated microcontroller
     uint8_t  count;     // number of bytes to write (59 max)
-    uint8_t  data[count];
-  } writeMemory;
+    uint8_t  data[];
+  } *writeMemory = NULL;
 
   if (address > 0xff) return (-1);
   if (count > 59) count = 59;
 
-  writeMemory.reportID = MEM_WRITE;
-  writeMemory.address = address;
-  writeMemory.count = count;
-  writeMemory.type = type;
+  writeMemory = (struct writeMemory_t *) malloc(sizeof(struct writeMemory_t) + count * sizeof(uint8_t) );
+  if(!writeMemory) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
+  }
+  writeMemory->reportID = MEM_WRITE;
+  writeMemory->address = address;
+  writeMemory->count = count;
+  writeMemory->type = type;
 
   for ( i = 0; i < count; i++ ) {
-    writeMemory.data[i] = data[i];
+    writeMemory->data[i] = data[i];
   }
 
-  PMD_SendOutputReport(hid, (uint8_t *) &writeMemory,  sizeof(writeMemory));
-
+  PMD_SendOutputReport(hid, (uint8_t *) writeMemory,  sizeof(struct writeMemory_t)+count-1);
+  free(writeMemory);
   return 0;
 }
 

--- a/USB/mcc-libusb/usb-temp.c
+++ b/USB/mcc-libusb/usb-temp.c
@@ -276,23 +276,28 @@ int usbWriteMemory_USBTEMP(hid_device *hid, uint16_t address, uint8_t type, uint
     uint16_t address;   // start address for the write (0x00-0xFF)
     uint8_t  type;      // 0 = main microcontroller  1 = isolated microcontroller
     uint8_t  count;     // number of bytes to write (59 max)
-    uint8_t  data[count];
-  } writeMemory;
+    uint8_t  data[1];
+  } *writeMemory = NULL;
 
   if (address > 0xff) return -1;
   if (count > 59) count = 59;
 
-  writeMemory.reportID = MEM_WRITE;
-  writeMemory.address = address;
-  writeMemory.count = count;
-  writeMemory.type = type;
+  writeMemory = (struct writeMemory_t *) malloc(sizeof(struct writeMemory_t) + count * sizeof(uint8_t) );
+  if(!writeMemory) {
+    printf("Couldn't allocate memory for write\n");
+    return(-1);
+  }
+  writeMemory->reportID = MEM_WRITE;
+  writeMemory->address = address;
+  writeMemory->count = count;
+  writeMemory->type = type;
 
   for ( i = 0; i < count; i++ ) {
-    writeMemory.data[i] = data[i];
+    writeMemory->data[i] = data[i];
   }
 
-  PMD_SendOutputReport(hid, (uint8_t *) &writeMemory,  sizeof(writeMemory));
-
+  PMD_SendOutputReport(hid, (uint8_t *) writeMemory,  sizeof(struct writeMemory_t)+count-1);
+  free(writeMemory);
   return 0;
 }
 


### PR DESCRIPTION
The Makefile is probably not important for the package, but was included just for ease of definition to different environments.

For each USB*.c file, the write routine dynamically allocates a buffer area for the write function, fills it in, outputs it, and then frees the allocated area.

This  is only the second repo I've made changes to, so feel free to criticize....